### PR TITLE
Allow zero metric point values

### DIFF
--- a/index.js
+++ b/index.js
@@ -61,7 +61,7 @@ CachetAPI.prototype.publishMetricPoint = function (metricPoint) {
         }
 
         // Check for missing metric value
-        if (!metricPoint.value) {
+        if (metricPoint.value === null) {
             return reject(new Error('Please provide the metric point value.'));
         }
 


### PR DESCRIPTION
When trying to publish a metric, if it's value is zero, it will fail. This PR fixes that.