### PR TITLE
feat(ca certs) added check for ca

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,6 +37,9 @@ function CachetAPI(options) {
         // Cachet API authentication header
         'X-Cachet-Token': options.apiKey
     };
+    
+    // Use ca certificate if one is provided
+    this.ca = (options.ca ? options.ca : '');    
 }
 
 CachetAPI.prototype.publishMetricPoint = function (metricPoint) {
@@ -70,7 +73,8 @@ CachetAPI.prototype.publishMetricPoint = function (metricPoint) {
             method: 'POST',
             json: metricPoint,
             headers: that.headers,
-            url: that.url + '/metrics/' + metricPoint.id + '/points'
+            url: that.url + '/metrics/' + metricPoint.id + '/points',
+            ca: that.ca
         };
 
         // Execute request
@@ -126,7 +130,8 @@ CachetAPI.prototype.reportIncident = function (incident) {
             method: 'POST',
             json: incident,
             headers: that.headers,
-            url: that.url + '/incidents'
+            url: that.url + '/incidents',
+            ca: that.ca
         };
 
         // Execute request
@@ -153,7 +158,8 @@ CachetAPI.prototype.getComponentById = function (id) {
             method: 'GET',
             json: true,
             headers: that.headers,
-            url: that.url + '/components/' + id
+            url: that.url + '/components/' + id,
+            ca: that.ca
         };
 
         // Execute request


### PR DESCRIPTION
**Add check for ca cert in requests**

- Will provide caller with the possibility to specify a valid ca cert when the Cachet server is internal and using a ca cert
- Simple change using ca value of requests module
- Closes #9 

_Embarassing disclaimer: I'm very sorry that I'm actually unable to test this at the moment as I don't have the right setup on my PC here!_